### PR TITLE
Implementing guard routing

### DIFF
--- a/front-end/src/app-routing/app-routing.module.ts
+++ b/front-end/src/app-routing/app-routing.module.ts
@@ -8,6 +8,7 @@ import {RegisterComponent} from "../component/page/register/register.component";
 import {AppSettingsComponent} from "../component/page/app-settings/app-settings.component";
 import {FileTypesComponent} from "../component/page/app-settings/page/file-types/file-types.component";
 import {AssetCategoryComponent} from "../component/page/app-settings/page/asset-category/asset-category.component";
+import {AppSettingsGuard} from "../component/page/app-settings/app-settings.guard";
 
 /**
  * The list of routes of this application.
@@ -18,7 +19,7 @@ const routes: Routes = [
   {path: RouteList.PAGE_LOGIN, component: LoginComponent},
   {path: RouteList.PAGE_REGISTER, component: RegisterComponent},
   {
-    path: RouteList.PAGE_APP_SETTINGS, component: AppSettingsComponent, children: [
+    path: RouteList.PAGE_APP_SETTINGS, component: AppSettingsComponent, canActivate: [AppSettingsGuard], children: [
     {path: RouteList.PAGE_FILE_TYPES, component: FileTypesComponent, outlet: "settings"},
     {path: RouteList.PAGE_ASSET_CATEGORY, component: AssetCategoryComponent, outlet: "settings"}
   ]

--- a/front-end/src/app-routing/app-routing.module.ts
+++ b/front-end/src/app-routing/app-routing.module.ts
@@ -20,8 +20,8 @@ const routes: Routes = [
   {path: RouteList.PAGE_REGISTER, component: RegisterComponent},
   {
     path: RouteList.PAGE_APP_SETTINGS, component: AppSettingsComponent, canActivate: [AppSettingsGuard], children: [
-    {path: RouteList.PAGE_FILE_TYPES, component: FileTypesComponent, outlet: "settings"},
-    {path: RouteList.PAGE_ASSET_CATEGORY, component: AssetCategoryComponent, outlet: "settings"}
+    {path: RouteList.PAGE_FILE_TYPES, component: FileTypesComponent},
+    {path: RouteList.PAGE_ASSET_CATEGORY, component: AssetCategoryComponent}
   ]
   },
 ];

--- a/front-end/src/app.module.ts
+++ b/front-end/src/app.module.ts
@@ -20,6 +20,7 @@ import {FormControlDirective} from '@angular/forms';
 import {ValidatorModule} from "./validate/validator.module";
 import {AssetCategoryComponent} from './component/page/app-settings/page/asset-category/asset-category.component';
 import {RouterModule} from "@angular/router";
+import {AppSettingsGuard} from "./component/page/app-settings/app-settings.guard";
 
 @NgModule({
   declarations: [
@@ -52,7 +53,7 @@ import {RouterModule} from "@angular/router";
     RouterModule,
     MatTabsModule
   ],
-  providers: [SecurityService],
+  providers: [SecurityService, AppSettingsGuard],
   bootstrap: [AppComponent]
 })
 export class AppModule {

--- a/front-end/src/component/page/app-settings/app-settings.component.html
+++ b/front-end/src/component/page/app-settings/app-settings.component.html
@@ -1,4 +1,4 @@
-<div *ngIf="hasRole('ADMIN')" class="app-settings">
+<div class="app-settings">
   <button mat-button [routerLink]="['/app-settings',{outlets: {'settings': ['file-types']}}] ">
     File types
   </button>
@@ -7,6 +7,6 @@
   </button>
 </div>
 
-<div *ngIf="hasRole('ADMIN')" class="setting-content">
+<div class="setting-content">
   <router-outlet name="settings"></router-outlet>
 </div>

--- a/front-end/src/component/page/app-settings/app-settings.component.html
+++ b/front-end/src/component/page/app-settings/app-settings.component.html
@@ -1,12 +1,12 @@
 <div class="app-settings">
-  <button mat-button [routerLink]="['/app-settings',{outlets: {'settings': ['file-types']}}] ">
+  <button mat-button [routerLink]="['./' + RouteList.PAGE_FILE_TYPES]">
     File types
   </button>
-  <button mat-button [routerLink]="['/app-settings', {outlets: {'settings':['asset-category']}}]">
+  <button mat-button [routerLink]="['./' + RouteList.PAGE_ASSET_CATEGORY]">
     Asset category
   </button>
 </div>
 
 <div class="setting-content">
-  <router-outlet name="settings"></router-outlet>
+  <router-outlet></router-outlet>
 </div>

--- a/front-end/src/component/page/app-settings/app-settings.component.html
+++ b/front-end/src/component/page/app-settings/app-settings.component.html
@@ -1,8 +1,8 @@
 <div class="app-settings">
-  <button mat-button [routerLink]="['./' + RouteList.PAGE_FILE_TYPES]">
+  <button mat-button [routerLink]="['./file-types'] ">
     File types
   </button>
-  <button mat-button [routerLink]="['./' + RouteList.PAGE_ASSET_CATEGORY]">
+  <button mat-button [routerLink]="['./asset-category']">
     Asset category
   </button>
 </div>

--- a/front-end/src/component/page/app-settings/app-settings.guard.spec.ts
+++ b/front-end/src/component/page/app-settings/app-settings.guard.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed, async, inject } from '@angular/core/testing';
+
+import { AppSettingsGuard } from './app-settings.guard';
+
+describe('AppSettingsGuard', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AppSettingsGuard]
+    });
+  });
+
+  it('should ...', inject([AppSettingsGuard], (guard: AppSettingsGuard) => {
+    expect(guard).toBeTruthy();
+  }));
+});

--- a/front-end/src/component/page/app-settings/app-settings.guard.ts
+++ b/front-end/src/component/page/app-settings/app-settings.guard.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+import {SecurityService} from "../../../service/security.service";
+
+/**
+ * The class is for activation rout guard.
+ *
+ * @author Denis Lesheniuk.
+ */
+@Injectable()
+export class AppSettingsGuard implements CanActivate {
+  constructor(private readonly security: SecurityService){}
+  canActivate(
+    next: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot): Observable<boolean> | Promise<boolean> | boolean {
+    const isAdmin = this.security.hasRole('ADMIN');
+    return isAdmin;
+  }
+}


### PR DESCRIPTION
Implementing guard routing for app-settings component.
- Now there is no need to use the *ngIf dirictive  to check the access rights to the app-setting page content. 
(page is not available for users without a role "ADMIN").

Simplified implementation of app routing for app-settings component. 
- In our case, we can do without named router-outlet.
(Now the link has a normal form: http://localhost:8080/#/app-settings/file-types).